### PR TITLE
umbilicus

### DIFF
--- a/base_fragment.py
+++ b/base_fragment.py
@@ -1,9 +1,14 @@
 from utils import Utils
 import numpy as np
-
+from enum import Enum
 from PyQt5.QtGui import QColor
 
 class BaseFragment:
+    class Type(Enum):
+        TRGL_FRAGMENT = "3D"
+        FRAGMENT = "2.5D" 
+        UMBILICUS = "U"
+
     def __init__(self, name):
         self.name = name
         self.color = QColor()
@@ -12,6 +17,7 @@ class BaseFragment:
         self.modified = Utils.timestamp()
         self.valid = False
         self.project = None
+        self.type = None
 
     def notifyModified(self, tstamp=""):
         if tstamp == "":
@@ -214,8 +220,12 @@ class BaseFragment:
         bvec = (trgls[:,0] == pt_index) | (trgls[:,1] == pt_index) | (trgls[:,2] == pt_index)
         tindexes = np.where(bvec)[0]
         return tindexes.tolist()
+    
+    def getType(self):
+        return self.type.value if self.type else None
 
 class BaseFragmentView:
+
     def __init__(self, project_view, fragment):
         self.project_view = project_view
         self.fragment = fragment
@@ -228,7 +238,7 @@ class BaseFragmentView:
         self.map_corners = None
         self.modified = Utils.timestamp()
         self.local_points_modified = Utils.timestamp()
-        self.normal_offset = 0.
+        self.normal_offset = 0
 
     def allowAutoExtrapolation(self):
         return False

--- a/fragment.py
+++ b/fragment.py
@@ -38,6 +38,7 @@ class FragmentsModel(QtCore.QAbstractTableModel):
             "Hide\nMesh",
             "Name",
             "Color",
+            "Type",  # Add new column
             "Dir",
             "Pts",
             "cm^2"
@@ -49,6 +50,7 @@ class FragmentsModel(QtCore.QAbstractTableModel):
             "Select which fragments have their mesh hidden;\nclick box to select",
             "Name of the fragment; click to edit",
             "Color of the fragment; click to edit",
+            "Type of fragment (2.5D or 3D)",  # Add new tooltip
             "Direction (orientation) of the fragment",
             "Number of points currently in fragment",
             "Fragment area in square centimeters"
@@ -178,6 +180,14 @@ class FragmentsModel(QtCore.QAbstractTableModel):
             return len(fragment.gpoints)
         elif column == self.columnIndex("cm^2"):
             return "%.4f"%fragment_view.sqcm
+        elif column == self.columnIndex("Type"):
+            #will need to figure out how to update this is trgl and umbilicus without circular imports
+            if isinstance(fragment, Fragment):
+                return "2.5D" 
+            # elif isinstance(fragment, UmbilicusFragment):
+            #     return "U"
+            else:
+                return "3D"
         else:
             return None
 
@@ -1798,7 +1808,8 @@ class FragmentView(BaseFragmentView):
 
     def trgls(self):
         if self.tri is None:
-            return None
+            # Return empty array instead of None for new fragments
+            return np.zeros((0,3), dtype=np.int32)
         return self.tri.simplices
 
     # return True if succeeds, False if fails

--- a/fragment.py
+++ b/fragment.py
@@ -181,13 +181,7 @@ class FragmentsModel(QtCore.QAbstractTableModel):
         elif column == self.columnIndex("cm^2"):
             return "%.4f"%fragment_view.sqcm
         elif column == self.columnIndex("Type"):
-            #will need to figure out how to update this is trgl and umbilicus without circular imports
-            if isinstance(fragment, Fragment):
-                return "2.5D" 
-            # elif isinstance(fragment, UmbilicusFragment):
-            #     return "U"
-            else:
-                return "3D"
+            return fragment.getType()
         else:
             return None
 
@@ -257,6 +251,7 @@ class Fragment(BaseFragment):
 
         # History of gpoints, for undo functionality
         self.gpoints_history : LifoQueue = LifoQueue(100)
+        self.type = BaseFragment.Type.FRAGMENT
 
     def createView(self, project_view):
         return FragmentView(project_view, self)

--- a/gl_data_window.py
+++ b/gl_data_window.py
@@ -375,6 +375,8 @@ class GLDataWindow(DataWindow):
             mfvi = indexed_fvs.index(mfv)
         if mfvi < 0:
             return None
+        if mfv.fragment.getType() == "U":
+            return None
         # indexes of rows where fragment_view matches mfvi
         # matches = (xyfvs[:,2] == mfvi).nonzero()[0]
 

--- a/gl_surface_window.py
+++ b/gl_surface_window.py
@@ -1030,7 +1030,7 @@ class GLSurfaceWindowChild(GLDataWindowChild):
 
         pv = dw.window.project_view
         mfv = self.active_fragment
-        if mfv is None:
+        if mfv is None or mfv.fragment.getType() == "U":
             # print("No fragment visible")
             return
 

--- a/khartes.py
+++ b/khartes.py
@@ -17,6 +17,8 @@ class Khartes():
         self.app = app
         self.window = window
         window.show()
+        window.loadProject("/Users/jamesdarby/Documents/VesuviusScroll/GP/khartes/khartes_project/overlay_testing.khprj")
+
 
 fmt = QSurfaceFormat()
 # Note that pyQt5 only supports OpenGL versions 2.0, 2.1, and 4.1 Core :

--- a/khartes.py
+++ b/khartes.py
@@ -17,8 +17,6 @@ class Khartes():
         self.app = app
         self.window = window
         window.show()
-        window.loadProject("/Users/jamesdarby/Documents/VesuviusScroll/GP/khartes/khartes_project/overlay_testing.khprj")
-
 
 fmt = QSurfaceFormat()
 # Note that pyQt5 only supports OpenGL versions 2.0, 2.1, and 4.1 Core :

--- a/main_window.py
+++ b/main_window.py
@@ -1883,11 +1883,10 @@ class MainWindow(QMainWindow):
             
         # Show confirmation dialog
         reply = QMessageBox.question(self, 'Delete Volume',
-                                   f'Are you sure you want to delete volume "{cv.name}"?',
-                                   QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+                               f'Are you sure you want to remove volume "{cv.name}" from the project?',
+                               QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
         if reply == QMessageBox.Yes:
-            # Remove from project
             self.volumes_table.model().beginResetModel()
             
             # Clear current volume if it's the one being deleted
@@ -1898,9 +1897,20 @@ class MainWindow(QMainWindow):
             for i, ovv in enumerate(pv.overlay_volume_views):
                 if ovv is not None and ovv.volume == cv:
                     self.setOverlay(i, None)
+        
+            # Remove the .volzarr file from the project's volumes directory
+            
+            volzarr_file = pv.project.volumes_path / (cv.name + '.volzarr')
+            print("volzarr_file", volzarr_file)
+            try:
+                if volzarr_file.exists():
+                    volzarr_file.unlink()
+            except Exception as e:
+                print(f"Warning: Failed to remove volzarr file {volzarr_file}: {e}")
                     
             pv.project.removeVolume(cv)
             self.volumes_table.model().endResetModel()
+            pv.project.notifyModified()
 
     def deleteActiveFragment(self):
         pv = self.project_view

--- a/main_window.py
+++ b/main_window.py
@@ -1311,9 +1311,10 @@ class MainWindow(QMainWindow):
         create_frag.setStyleSheet("QPushButton { %s; padding: 5; }"%self.highlightedBackgroundStyle())
         hlayout.addWidget(create_frag)
 
-        create_25d_frag = Create25DFragmentButton(self)
-        create_25d_frag.setStyleSheet("QPushButton { %s; padding: 5; }"%self.highlightedBackgroundStyle())
-        hlayout.addWidget(create_25d_frag)
+        #Causes crashes with OpenGL classes...
+        # create_25d_frag = Create25DFragmentButton(self)
+        # create_25d_frag.setStyleSheet("QPushButton { %s; padding: 5; }"%self.highlightedBackgroundStyle())
+        # hlayout.addWidget(create_25d_frag)
 
         create_umbilicus_frag = CreateUmbilicusFragmentButton(self)
         create_umbilicus_frag.setStyleSheet("QPushButton { %s; padding: 5; }"%self.highlightedBackgroundStyle())

--- a/main_window.py
+++ b/main_window.py
@@ -1931,8 +1931,41 @@ class MainWindow(QMainWindow):
                                    QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
         if reply == QMessageBox.Yes:
+            # Find and delete the fragment's files from the project's fragments directory
+            # The files are named with the fragment's creation timestamp
+            timestamp = mf.created.replace('-','').replace('T','').replace(':','').replace('.','').replace('Z','')[:14]
+            print("timestamp", timestamp)
+            print("fragments_path", pv.project.fragments_path)
+            fragment_base = os.path.join(os.path.dirname(pv.project.fragments_path), pv.project.fragments_path.name, timestamp)
+            obj_file = fragment_base + '.obj'
+            mtl_file = fragment_base + '.mtl'
+            
+            # Comment out deleting fragments from previous versions for better recovery of files
+            # Also check for _prev and _prev_2 versions
+            # prev_base = os.path.join(os.path.dirname(pv.project.fragments_path), pv.project.fragments_path.name + "_prev", timestamp) 
+            # prev2_base = os.path.join(os.path.dirname(pv.project.fragments_path), pv.project.fragments_path.name + "_prev_2", timestamp)
+            # obj_prev = prev_base + '.obj'
+            # mtl_prev = prev_base + '.mtl'
+            # obj_prev2 = prev2_base + '.obj'
+            # mtl_prev2 = prev2_base + '.mtl'
+            
+            files_to_delete = [
+                obj_file, mtl_file,
+                # obj_prev, mtl_prev,
+                # obj_prev2, mtl_prev2
+            ]
+            print("files_to_delete", files_to_delete)
+            
+            for file_path in files_to_delete:
+                try:
+                    if os.path.exists(file_path):
+                        os.remove(file_path)
+                        print(f"Deleted fragment file: {file_path}")
+                except Exception as e:
+                    print(f"Warning: Failed to remove fragment file {file_path}: {e}")
+            # /Users/jamesdarby/Documents/VesuviusScroll/GP/khartes/khartes_project/overlay_testing.khprj/fragments/20241128120938.obj
+            # /Users/jamesdarby/Documents/VesuviusScroll/GP/khartes/khartes_project/overlay_testing.khprj/fragments/20241128120938.obj
             # Remove from project
-            self.fragments_table.model().beginResetModel()
             pv.project.removeFragment(mf)
             self.setFragments()
             self.fragments_table.model().endResetModel()

--- a/project.py
+++ b/project.py
@@ -762,3 +762,11 @@ class Project:
             if v.is_streaming:
                 return True
         return False
+
+    def removeFragment(self, fragment):
+        if fragment in self.fragments:
+            self.fragments.remove(fragment)
+            for pv in self.project_views:
+                if fragment in pv.fragments:
+                    del pv.fragments[fragment]
+            self.notifyModified()

--- a/project.py
+++ b/project.py
@@ -770,3 +770,11 @@ class Project:
                 if fragment in pv.fragments:
                     del pv.fragments[fragment]
             self.notifyModified()
+
+    def removeVolume(self, volume):
+        if volume in self.volumes:
+            self.volumes.remove(volume)
+            for pv in self.project_views:
+                if volume in pv.volumes:
+                    del pv.volumes[volume]
+            self.notifyModified()

--- a/project.py
+++ b/project.py
@@ -765,6 +765,8 @@ class Project:
 
     def removeFragment(self, fragment):
         if fragment in self.fragments:
+            print("removing fragment", fragment.name, fragment.created)
+            print(fragment)
             self.fragments.remove(fragment)
             for pv in self.project_views:
                 if fragment in pv.fragments:

--- a/trgl_fragment.py
+++ b/trgl_fragment.py
@@ -24,6 +24,7 @@ class TrglFragment(BaseFragment):
         self.trgls = np.zeros((0,3), dtype=np.int32)
         self.direction = 0
         self.params = {}
+        self.type = BaseFragment.Type.TRGL_FRAGMENT
 
     # class function
     # expected to return a list of fragments, but always

--- a/trgl_fragment.py
+++ b/trgl_fragment.py
@@ -333,7 +333,7 @@ class TrglFragment(BaseFragment):
             try:
                 ofj = jfilename.open("w")
                 print(info_txt, file=ofj)
-            except Excepton as e:
+            except Exception as e:
                 print("Could not open %s: %s"%(str(jfilename), e))
                 return
 

--- a/umbilicus_fragment.py
+++ b/umbilicus_fragment.py
@@ -5,6 +5,7 @@ class UmbilicusFragment(Fragment):
     def __init__(self, name, direction):
         super(UmbilicusFragment, self).__init__(name, direction)
         self.is_umbilicus = True # Flag to identify umbilicus fragments
+        self.type = Fragment.Type.UMBILICUS
         
     def createView(self, project_view):
         return UmbilicusFragmentView(project_view, self)
@@ -27,20 +28,73 @@ class UmbilicusFragment(Fragment):
 class UmbilicusFragmentView(FragmentView):
     def __init__(self, project_view, fragment):
         super(UmbilicusFragmentView, self).__init__(project_view, fragment)
+        self.segments = None
+        self.manual_points = None  # Store original user-placed points
+        self.interpolated_points = None  # Store interpolated points
         
+    def interpolatePoints(self):
+        """Create linearly interpolated points between manual points"""
+        if len(self.manual_points) < 2:
+            self.interpolated_points = np.array([])
+            return
+            
+        # Sort manual points by Z
+        z_order = np.argsort(self.manual_points[:, 2])
+        sorted_points = self.manual_points[z_order]
+        
+        # Update manual_points to maintain sorted order
+        self.manual_points = sorted_points
+        
+        all_interpolated = []
+        
+        # Interpolate between each consecutive pair of points
+        for i in range(len(sorted_points) - 1):
+            p1 = sorted_points[i]
+            p2 = sorted_points[i + 1]
+            
+            # Calculate number of points based on z distance
+            z_dist = abs(p2[2] - p1[2])
+            num_points = max(2, int(z_dist))  # At least 2 points to include endpoints
+            
+            # Create evenly spaced points between p1 and p2
+            t = np.linspace(0, 1, num_points)[1:-1]  # Exclude endpoints to avoid duplicates
+            
+            # Linear interpolation for each dimension
+            interp_points = np.array([
+                p1[0] + (p2[0] - p1[0]) * t,  # x coordinates
+                p1[1] + (p2[1] - p1[1]) * t,  # y coordinates
+                p1[2] + (p2[2] - p1[2]) * t   # z coordinates
+            ]).T
+            
+            all_interpolated.append(interp_points)
+        
+        # Combine all interpolated points
+        if all_interpolated:
+            self.interpolated_points = np.vstack(all_interpolated)
+        else:
+            self.interpolated_points = np.array([])
+
     def createZsurf(self, do_update=True):
         # Override to skip triangulation and just sort points by Z
         if len(self.fpoints) <= 1:
             self.zsurf = None
             self.ssurf = None
+            self.line = None
+            self.segments = None
             return
             
-        # Sort points by Z coordinate
-        sorted_points = self.fpoints[self.fpoints[:,2].argsort()]
+        # Sort points by Z coordinate and break ties using point indices
+        # This ensures stable sorting when points have the same Z value
+        indices = np.arange(len(self.fpoints))
+        sorted_indices = np.lexsort((indices, self.fpoints[:,2]))
+        sorted_points = self.fpoints[sorted_indices]
         self.line = sorted_points
         
         # Create line segments between consecutive points
-        self.segments = np.array([sorted_points[:-1], sorted_points[1:]]).transpose(1,0,2)
+        if len(sorted_points) > 1:
+            self.segments = np.array([sorted_points[:-1], sorted_points[1:]]).transpose(1,0,2)
+        else:
+            self.segments = None
         
         # Skip the rest of createZsurf since we don't need triangulation
         self.zsurf = None 
@@ -51,8 +105,102 @@ class UmbilicusFragmentView(FragmentView):
         self.tri = None
         if self.fpoints.shape[0] <= 1:
             self.line = None
+            self.segments = None
             return
             
-        # Sort points by Z and store as line
-        sorted_points = self.fpoints[self.fpoints[:,2].argsort()]
+        # Sort points by Z and break ties using point indices
+        indices = np.arange(len(self.fpoints))
+        sorted_indices = np.lexsort((indices, self.fpoints[:,2]))
+        sorted_points = self.fpoints[sorted_indices]
         self.line = sorted_points
+        return
+
+    def getLinesOnSlice(self, axis, position):
+        """Override to return line segments that intersect with the given slice"""
+        if self.segments is None or len(self.segments) == 0:
+            return None, None
+        
+        return None, None
+            
+        # Find segments that cross the slice plane
+        crossings = []
+        trglist = []
+        
+        for i, segment in enumerate(self.segments):
+            p1, p2 = segment
+            
+            # Check if segment crosses the slice plane
+            if (p1[axis] <= position <= p2[axis]) or (p2[axis] <= position <= p1[axis]):
+                # Linear interpolation to find crossing point
+                if abs(p2[axis] - p1[axis]) > 1e-10:  # Small threshold for floating point comparison
+                    t = (position - p1[axis]) / (p2[axis] - p1[axis])
+                    crossing = p1 + t * (p2 - p1)
+                    crossings.append([crossing, crossing])  # Duplicate point to create a line segment
+                    trglist.append(i)
+                else:
+                    # Points are at same height, use p1
+                    crossings.append([p1, p1])
+                    trglist.append(i)
+                    
+        if len(crossings) == 0:
+            return None, None
+            
+        return np.array(crossings), np.array(trglist)
+
+    def workingTrgls(self):
+        """Override to return a boolean array for line segments"""
+        if self.segments is None:
+            return np.array([], dtype=bool)
+        return np.ones(len(self.segments), dtype=bool)
+
+    def trgls(self):
+        """Override to return indices for line segments"""
+        if self.segments is None:
+            return np.array([], dtype=np.int32)
+        return np.arange(len(self.segments), dtype=np.int32)
+
+    def hasWorkingNonWorking(self):
+        """Override to indicate all segments are working"""
+        return (True, False)
+
+    def addPoint(self, tijk, stxy):
+        """Override addPoint to handle both manual and interpolated points"""
+        # Convert to fragment's coordinate system
+        fijk = self.vijkToFijk(tijk)
+        
+        # Round to nearest integer
+        ijk = np.rint(np.array(fijk))
+        
+        # Find any existing points with the same Z coordinate
+        z_matches = np.where(np.abs(self.fpoints[:, 2] - ijk[2]) < 1e-10)[0]
+        
+        if len(z_matches) > 0:
+            # Delete existing point at this Z value
+            self.pushFragmentState()
+            self.fragment.gpoints = np.delete(self.fragment.gpoints, z_matches, 0)
+            if self.manual_points is not None:
+                # Also remove from manual points if it exists there
+                manual_z_matches = np.where(np.abs(self.manual_points[:, 2] - ijk[2]) < 1e-10)[0]
+                if len(manual_z_matches) > 0:
+                    self.manual_points = np.delete(self.manual_points, manual_z_matches, 0)
+    
+        # Create new point
+        gijk = self.cur_volume_view.transposedIjkToGlobalPosition(tijk)
+        self.pushFragmentState()
+        self.fragment.gpoints = np.append(self.fragment.gpoints, np.reshape(gijk, (1,3)), axis=0)
+        
+        # Add to manual points array
+        if self.manual_points is None:
+            self.manual_points = np.reshape(gijk, (1,3))
+        else:
+            self.manual_points = np.append(self.manual_points, np.reshape(gijk, (1,3)), axis=0)
+        
+        # If we have more than 2 manual points, create interpolated points
+        if len(self.manual_points) >= 2:
+            self.interpolatePoints()
+            if self.interpolated_points is not None and len(self.interpolated_points) > 0:
+                # Update fragment points to include both manual and interpolated points
+                self.fragment.gpoints = np.vstack((self.manual_points, self.interpolated_points))
+        
+        self.setLocalPoints(True, False)
+        self.fragment.notifyModified()

--- a/umbilicus_fragment.py
+++ b/umbilicus_fragment.py
@@ -1,0 +1,58 @@
+from fragment import Fragment, FragmentView
+import numpy as np
+
+class UmbilicusFragment(Fragment):
+    def __init__(self, name, direction):
+        super(UmbilicusFragment, self).__init__(name, direction)
+        self.is_umbilicus = True # Flag to identify umbilicus fragments
+        
+    def createView(self, project_view):
+        return UmbilicusFragmentView(project_view, self)
+        
+    def meshExportNeedsInfill(self):
+        return False # Umbilicus doesn't need infill since it's just a line
+        
+    def badTrglsBySkinniness(self, tri, min_roundness):
+        # Override to do nothing since we don't use triangulation
+        return []
+        
+    def badTrglsByMaxAngle(self, tri):
+        # Override to do nothing since we don't use triangulation 
+        return []
+        
+    def badTrglsByNormal(self, tri, pts):
+        # Override to do nothing since we don't use triangulation
+        return []
+
+class UmbilicusFragmentView(FragmentView):
+    def __init__(self, project_view, fragment):
+        super(UmbilicusFragmentView, self).__init__(project_view, fragment)
+        
+    def createZsurf(self, do_update=True):
+        # Override to skip triangulation and just sort points by Z
+        if len(self.fpoints) <= 1:
+            self.zsurf = None
+            self.ssurf = None
+            return
+            
+        # Sort points by Z coordinate
+        sorted_points = self.fpoints[self.fpoints[:,2].argsort()]
+        self.line = sorted_points
+        
+        # Create line segments between consecutive points
+        self.segments = np.array([sorted_points[:-1], sorted_points[1:]]).transpose(1,0,2)
+        
+        # Skip the rest of createZsurf since we don't need triangulation
+        self.zsurf = None 
+        self.ssurf = None
+        
+    def triangulate(self):
+        # Override to skip triangulation
+        self.tri = None
+        if self.fpoints.shape[0] <= 1:
+            self.line = None
+            return
+            
+        # Sort points by Z and store as line
+        sorted_points = self.fpoints[self.fpoints[:,2].argsort()]
+        self.line = sorted_points


### PR DESCRIPTION
Built on top of the delete buttons branch so it will have those changes too

Adds a type enum to base fragment and displays that as a field in the fragment table.

Commented out the 2.5d fragment creation button as working with those and the gl surface/data window classes cause crashes, but left the creation infrastructure in place in case support for 2.5d + gl classes is later added.

Added an umbilicus fragment, inheriting from the 2.5d fragments. It avoids the crashes related to 2.5d segments by not rendering anything on the surface window by checking the fragment type and using different addPoint logic.

It interpolates points between each manually placed point along the z-axis to form a line and always have a point on the z-plane to help create/refine umbilicus'.