### PR TITLE
Umbilicus saving bugfix

### DIFF
--- a/base_fragment.py
+++ b/base_fragment.py
@@ -2,6 +2,7 @@ from utils import Utils
 import numpy as np
 from enum import Enum
 from PyQt5.QtGui import QColor
+import json
 
 class BaseFragment:
     class Type(Enum):
@@ -318,6 +319,9 @@ class BaseFragmentView:
         return
 
     def reparameterize(self):
+        return
+    
+    def fragFromDict(self):
         return
 
     # direction is not used here, but this notifies fragment view

--- a/trgl_fragment.py
+++ b/trgl_fragment.py
@@ -465,7 +465,15 @@ class TrglFragment(BaseFragment):
         info['modified'] = self.modified
         info['color'] = self.color.name()
         info['type'] = self.type.value if self.type else Fragment.Type.TRGL_FRAGMENT.value
-        info['params'] = self.params
+        
+        # Convert any NumPy arrays in params to lists
+        params = {}
+        for key, value in self.params.items():
+            if isinstance(value, np.ndarray):
+                params[key] = value.tolist()
+            else:
+                params[key] = value
+        info['params'] = params
         info['obj_path'] = str(self.obj_path) if self.obj_path else None
         # Don't save gpoints/trgls in JSON as they're in the OBJ file
         return info

--- a/umbilicus_fragment.py
+++ b/umbilicus_fragment.py
@@ -2,6 +2,7 @@ from fragment import Fragment, FragmentView
 import numpy as np
 import os
 from utils import Utils
+import json
 
 from PyQt5.QtWidgets import (
         QDialog, QDialogButtonBox,
@@ -68,6 +69,12 @@ class UmbilicusFragment(Fragment):
                 if len(coords) >= 3:  # ensure we have x,y,z
                     points.append([float(x) for x in coords[:3]])
         return np.array(points)
+
+    def toDict(self):
+        info = super(UmbilicusFragment, self).toDict()
+        info['type'] = self.type.value if self.type else Fragment.Type.UMBILICUS.value
+        info['gpoints'] = self.gpoints.tolist()
+        return info
 
 class UmbilicusFragmentView(FragmentView):
     def __init__(self, project_view, fragment):


### PR DESCRIPTION
Umbilicus and Fragment were saving to the same all.json, one overwriting the other... Thus if both types existed, only one would be saved by the project.

This PR changes it so each fragment type uses its own .json to save, also updated trgl_fragment to use a .json to save metadata (so the name & color is actually saved!) and a obj_path from which the geometry is loaded, thus it also saves trgl fragment geometry as a .obj. 

Deleting fragments still works, creating, loading from obj etc all also seem to work.

Would recommend through testing though as this is improving the saving logic which is vital, also I didn't look at undo or the multisave/backup functionality.