### PR TITLE
adding glasbey colormap

### DIFF
--- a/volume.py
+++ b/volume.py
@@ -292,6 +292,7 @@ class ColormapSelectorDelegate(QtWidgets.QStyledItemDelegate):
             "cool": "matlab:cool",
             "bmr_3c": "chrisluts:bmr_3c",
             "rainbow": "gnuplot:rainbow",
+            "glasbey": "glasbey:glasbey",
             }
 
     def __init__(self, table, parent=None):


### PR DESCRIPTION
adding glasbey colormap to visualize different type of semantic segmentation predictions

e.g. predictions from horizontal/vertical fiber model

![image](https://github.com/user-attachments/assets/5a6f9525-ba15-47c8-a43a-f8f5400b2b02)

or predictions overlaid to original volume:
![image](https://github.com/user-attachments/assets/d950b1bc-81a8-47be-82f5-69be809fe096)
